### PR TITLE
Validation warnings feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "pk11-uri-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ categories = ["authentication", "config", "cryptography", "parser-implementation
 [dependencies]
 once_cell = "1.20.2"
 regex = "1.11.0"
+
+[features]
+default = ["validation", "debug_warnings"]
+validation = []
+debug_warnings = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "pk11-uri-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = """
 A zero-copy library to parse and validate PKCS#11 URIs in accordance to RFC7512 specifications.
+Validation (and debug warning) functionality is completely controllable by way of the features.
 """
 repository = "https://github.com/andrewoswald/pk11-uri-parser"
 readme = "README.md"
@@ -16,6 +17,30 @@ once_cell = "1.20.2"
 regex = "1.11.0"
 
 [features]
+
+# The default feature set is to always perform validation and
+# to provide `pkcs11 warning:` messages for debug builds
+# (assuming an attribute's value does not comply with RFC7512
+# "SHOULD/SHOULD NOT" guidelines).
+#
+# It's perfectly reasonable for `--release` builds to not require
+# any runtime validation (and its slight bit of overhead), so simply
+# annotate your dependency using `--no-default-features`, but be
+# aware that doing so introduces `expect("my expectation")` calls.
 default = ["validation", "debug_warnings"]
+
+# The RFC7512 specification defines specific criteria for
+# acceptable attribute values. This feature evaluates attribute
+# values and enforces validity.  The library will issue a
+# PK11URIError if a value violates the specification's rules.
 validation = []
+
+# The RFC7512 specification provides optional, best-practice
+# suggestions for attribute values (and vendor-specific naming).
+# This feature evaluates attribute values and will emit `pkcs11
+# warning:` messages when said messages do not comply with the
+# specification's "SHOULD/SHOULD NOT" (etc.) guidelines. As the
+# feature name implies, this feature is only relevant for debug
+# builds; warning related code is explicitly excluded from
+# `--release` builds.
 debug_warnings = []

--- a/README.md
+++ b/README.md
@@ -134,5 +134,12 @@ prints
 `NATO` vendor value: ["alpha", "bravo", "charlie"]
 ```
 
+## Crate feature flags
+
+At your disposal is the fine-grained control over validtion and debug warnings.  The default feature set it to *always* perform validation
+and to provide `pkcs11 warning:` messages when debug build attribute values do not comply with RFC7512 "SHOULD/SHOULD NOT" guidelines.  To
+do away with the default, simply assign `--no-default-features` in your pk11-uri-parser dependency stanza. Please be aware, however, that doing
+so will introduce `expect("my expectation")` calls required in the parsing logic.  See the [Cargo.toml](Cargo.toml) file for more details.
+
 ## License
 This project's source code and documentation are licensed under the MIT license. See the [LICENSE](LICENSE) file for details.

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,6 +14,7 @@ pub(crate) struct ValidationErr {
 #[derive(Debug)]
 pub(crate) struct VendorAttribute<'a>(pub(crate) &'a str);
 
+#[cfg(feature = "validation")]
 impl<'a> TryFrom<&'a str> for VendorAttribute<'a> {
     type Error = ValidationErr;
 
@@ -77,7 +78,23 @@ impl<'a> TryFrom<&'a str> for VendorAttribute<'a> {
     }
 }
 
+#[cfg(not(feature = "validation"))]
+impl<'a> From<&'a str> for VendorAttribute<'a> {
+
+    fn from(vendor_attr: &'a str) -> Self {
+        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
+        if vendor_attr.starts_with("x-") {
+            println!(
+                r#"pkcs11 warning: per RFC7512, the previously used convention of starting vendor attributes with an "x-" prefix is now deprecated.  Identified: `{vendor_attr}`."#
+            );
+        }
+
+        VendorAttribute(vendor_attr)
+    }
+}
+
 /// Values for *both* path and query components must not contain empty spaces or the '#' character.
+#[cfg(feature = "validation")]
 pub(crate) fn common_validation(value: &str) -> Option<ValidationErr> {
     if value.contains(' ') {
         return Some(ValidationErr {
@@ -105,7 +122,7 @@ pub(crate) fn common_validation(value: &str) -> Option<ValidationErr> {
 /// to identify potential issues of unsupported characters.  The intent
 /// of this function is to properly test attribute values in debug builds
 /// and make appropriate changes for usage prior to release builds.
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "debug_warnings"))]
 pub(crate) fn maybe_suggest_percent_encoding<const T: usize>(
     attribute: &str,
     value: &str,

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,16 @@ pub(crate) struct ValidationErr {
     pub(crate) help: String,
 }
 
+#[cfg(feature = "validation")]
+pub(crate) trait Validation<'a> {
+    fn validate(&self, value: &'a str) -> Result<(), ValidationErr>;
+}
+
+#[cfg(all(debug_assertions, feature = "debug_warnings"))]
+pub(crate) trait Warning<'a> {
+    fn maybe_warn(&self, value: &'a str);
+}
+
 /// A "newtype" that encapsulates `1*pk11-v-attr-nm-char` vendor-specific
 /// naming enforcement as well as verifying we don't allow standard
 /// attribute naming collisions.  This is basically where everything that's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,7 @@ impl<'a> PK11URIMapping<'a> {
 ///
 /// [rfc7512]: <https://datatracker.ietf.org/doc/html/rfc7512>
 pub fn parse(pk11_uri: &str) -> Result<PK11URIMapping, PK11URIError> {
+    #[cfg(feature = "validation")]
     if !pk11_uri.starts_with(PKCS11_SCHEME) {
         return Err(PK11URIError {
             pk11_uri: tidy(pk11_uri),
@@ -361,7 +362,7 @@ pub fn parse(pk11_uri: &str) -> Result<PK11URIMapping, PK11URIError> {
         // "...semantics of using both attributes in the same URI string is implementation specific
         //  but such use SHOULD be avoided.  Attribute "module-name" is preferred to "module-path" due
         //  to its system-independent nature, but the latter may be more suitable for development and debugging."
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
         if mapping.module_name.is_some() && mapping.module_path.is_some() {
             println!(
                 "pkcs11 warning: using both `module-name` and `module-path` SHOULD be avoided. \
@@ -370,7 +371,7 @@ pub fn parse(pk11_uri: &str) -> Result<PK11URIMapping, PK11URIError> {
         }
 
         // "If a URI contains both "pin-source" and "pin-value" query attributes, the URI SHOULD be refused as invalid."
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
         if mapping.pin_source.is_some() && mapping.pin_value.is_some() {
             println!(
                 r#"pkcs11 warning: a PKCS#11 URI containing both "pin-source" and "pin-value" query attributes SHOULD be refused as invalid."#

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //!     let mapping = parse(pk11_uri)?;
 //!
-//!     println!("{:?}", mapping);
+//!     println!("{mapping:?}");
 //!     Ok(())
 //! }
 //! ```
@@ -64,8 +64,8 @@
 //! ```
 //! // note: this isn't a valid pkcs11 uri
 //! let pk11_uri = "pkcs11:object=Private key for Card Authentication;pin-value=123456";
-//! let err = pk11_uri_parser::parse(pk11_uri).expect_err("empty spaces in value violation");
-//! println!("{:?}", err);
+//! #[cfg(feature = "validation")]
+//! println!("{err:?}", err=pk11_uri_parser::parse(pk11_uri).expect_err("empty spaces in value violation"));
 //! ```
 //! Attempting to parse that uri will result in a [PK11URIError].
 //! ```terminal
@@ -75,8 +75,8 @@
 //! ```
 //! // note: this isn't a valid pkcs11 uri
 //! let pk11_uri = "pkcs11:object=Private key for Card Authentication;pin-value=123456";
-//! let err = pk11_uri_parser::parse(pk11_uri).expect_err("empty spaces in value violation");
-//! println!("{err}");
+//! #[cfg(feature = "validation")]
+//! println!("{err}", err=pk11_uri_parser::parse(pk11_uri).expect_err("empty spaces in value violation"))
 //! ```
 //! ```terminal
 //! pkcs11:object=Private key for Card Authentication;pin-value=123456
@@ -88,8 +88,8 @@
 //! ```
 //! // note: again, this isn't a valid pkcs11 uri
 //! let pk11_uri = "pkcs11:object=Private%20key%20for%20Card%20Authentication;pin-value=123456";
-//! let err = pk11_uri_parser::parse(pk11_uri).expect_err("query component naming collision violation");
-//! println!("{err}");
+//! #[cfg(feature = "validation")]
+//! println!("{err}", err=pk11_uri_parser::parse(pk11_uri).expect_err("query component naming collision violation"));
 //! ```
 //! This will once again fail to parse and brings up the fact that this library will *fail-quickly* (ie, short-circuit *further* parsing) if any violation is found.
 //! ```terminal
@@ -131,6 +131,19 @@
 //! x-muppet: ["cookie<^^>monster!"]
 //! ```
 //! Any warning related code is explicitly **not** included in `--release` builds.
+//!
+//!  ## Crate feature flags
+//!
+//! As alluded to above, the crate's **default** feature set is to *always* perform validation and for
+//! debug builds, emit `pkcs11 warning:` messages when values do not comply with RFC7512 "SHOULD/
+//! SHOULD NOT" guidelines.
+//!
+//! > "But sir, I implore you, I've *thoroughly* tested my input!"
+//!
+//! I hear you barking, big dog! It's perfectly reasonable to not want validation (and/or warnings). You
+//! can eliminate that runtime overhead by utilizing the `--no-default-features` treatment on your dependency.
+//! It's important to note, however, that doing so will introduce `expect("my expectation")` calls to perform
+//! unwrap functionality required in the parsing.
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/pk11_qattr.rs
+++ b/src/pk11_qattr.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "validation")]
-use super::common::common_validation;
+use super::common::{common_validation, Validation};
 use super::common::{ValidationErr, VendorAttribute};
 use super::PK11URIMapping;
 
 #[cfg(all(debug_assertions, feature = "debug_warnings"))]
-use super::common::maybe_suggest_percent_encoding;
+use super::common::{maybe_suggest_percent_encoding, Warning};
 
 query_attributes!(
     pin_source for "pin-source",
@@ -13,51 +13,29 @@ query_attributes!(
     module_path for "module-path"
 );
 
-impl<'a> PK11QAttr<'a> {
-    #[cfg(feature = "validation")]
+#[cfg(feature = "validation")]
+impl<'a> Validation<'a> for PK11QAttr<'a> {
     fn validate(&self, value: &'a str) -> Result<(), ValidationErr> {
         if let Some(validation_err) = common_validation(value) {
             return Err(validation_err);
         }
-
-        // If debug build, emit warning messages for RFC7512 "SHOULD" ... violations:
-        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
-        {
-            if matches!(self, module_name(_))
-                && (value.starts_with("lib")
-                    || value.chars().any(|c| ['.', '/', '\\'].contains(&c)))
-            {
-                println!(
-                    r#"pkcs11 warning: the attribute "module-name" SHOULD contain a case-insensitive PKCS #11 module name (not path nor filename) without system-specific affices. Context: `module-name={value}`."#
-                );
-            }
-            // All query component values are `*pk11-qchar` so make a blanket call:
-            const PK11_QUERY_RES_AVAIL: [char; 3] = ['/', '?', '|'];
-            maybe_suggest_percent_encoding(self.to_str(), value, PK11_QUERY_RES_AVAIL);
-        }
-
         Ok(())
     }
+}
 
-    #[cfg(all(not(feature = "validation"), all(debug_assertions, feature = "debug_warnings")))]
-    fn validate(&self, value: &'a str) -> Result<(), ValidationErr> {
-        // If debug build, emit warning messages for RFC7512 "SHOULD" ... violations:
-        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
+#[cfg(all(debug_assertions, feature = "debug_warnings"))]
+impl<'a> Warning<'a> for PK11QAttr<'a> {
+    fn maybe_warn(&self, value: &'a str) {
+        if matches!(self, module_name(_))
+            && (value.starts_with("lib") || value.chars().any(|c| ['.', '/', '\\'].contains(&c)))
         {
-            if matches!(self, module_name(_))
-                && (value.starts_with("lib")
-                    || value.chars().any(|c| ['.', '/', '\\'].contains(&c)))
-            {
-                println!(
-                    r#"pkcs11 warning: the attribute "module-name" SHOULD contain a case-insensitive PKCS #11 module name (not path nor filename) without system-specific affices. Context: `module-name={value}`."#
-                );
-            }
-            // All query component values are `*pk11-qchar` so make a blanket call:
-            const PK11_QUERY_RES_AVAIL: [char; 3] = ['/', '?', '|'];
-            maybe_suggest_percent_encoding(self.to_str(), value, PK11_QUERY_RES_AVAIL);
+            println!(
+                r#"pkcs11 warning: the attribute "module-name" SHOULD contain a case-insensitive PKCS #11 module name (not path nor filename) without system-specific affices. Context: `module-name={value}`."#
+            );
         }
-
-        Ok(())
+        // All query component values are `*pk11-qchar` so make a blanket call:
+        const PK11_QUERY_RES_AVAIL: [char; 3] = ['/', '?', '|'];
+        maybe_suggest_percent_encoding(self.to_str(), value, PK11_QUERY_RES_AVAIL);
     }
 }
 
@@ -66,8 +44,8 @@ pub(crate) fn assign<'a>(
     mapping: &mut PK11URIMapping<'a>,
 ) -> Result<(), ValidationErr> {
     #[cfg(feature = "validation")]
-    let QueryAttribute{ attr, value } = QueryAttribute::try_from(pk11_qattr)?;
+    let QueryAttribute { attr, value } = QueryAttribute::try_from(pk11_qattr)?;
     #[cfg(not(feature = "validation"))]
-    let QueryAttribute{ attr, value } = QueryAttribute::from(pk11_qattr);
+    let QueryAttribute { attr, value } = QueryAttribute::from(pk11_qattr);
     attr.assign(value, mapping)
 }

--- a/src/pk11_qattr.rs
+++ b/src/pk11_qattr.rs
@@ -1,7 +1,9 @@
-use super::common::{common_validation, ValidationErr, VendorAttribute};
+#[cfg(feature = "validation")]
+use super::common::common_validation;
+use super::common::{ValidationErr, VendorAttribute};
 use super::PK11URIMapping;
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "debug_warnings"))]
 use super::common::maybe_suggest_percent_encoding;
 
 query_attributes!(
@@ -12,13 +14,35 @@ query_attributes!(
 );
 
 impl<'a> PK11QAttr<'a> {
+    #[cfg(feature = "validation")]
     fn validate(&self, value: &'a str) -> Result<(), ValidationErr> {
         if let Some(validation_err) = common_validation(value) {
             return Err(validation_err);
         }
 
         // If debug build, emit warning messages for RFC7512 "SHOULD" ... violations:
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
+        {
+            if matches!(self, module_name(_))
+                && (value.starts_with("lib")
+                    || value.chars().any(|c| ['.', '/', '\\'].contains(&c)))
+            {
+                println!(
+                    r#"pkcs11 warning: the attribute "module-name" SHOULD contain a case-insensitive PKCS #11 module name (not path nor filename) without system-specific affices. Context: `module-name={value}`."#
+                );
+            }
+            // All query component values are `*pk11-qchar` so make a blanket call:
+            const PK11_QUERY_RES_AVAIL: [char; 3] = ['/', '?', '|'];
+            maybe_suggest_percent_encoding(self.to_str(), value, PK11_QUERY_RES_AVAIL);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(all(not(feature = "validation"), all(debug_assertions, feature = "debug_warnings")))]
+    fn validate(&self, value: &'a str) -> Result<(), ValidationErr> {
+        // If debug build, emit warning messages for RFC7512 "SHOULD" ... violations:
+        #[cfg(all(debug_assertions, feature = "debug_warnings"))]
         {
             if matches!(self, module_name(_))
                 && (value.starts_with("lib")
@@ -41,6 +65,9 @@ pub(crate) fn assign<'a>(
     pk11_qattr: &'a str,
     mapping: &mut PK11URIMapping<'a>,
 ) -> Result<(), ValidationErr> {
+    #[cfg(feature = "validation")]
     let QueryAttribute{ attr, value } = QueryAttribute::try_from(pk11_qattr)?;
+    #[cfg(not(feature = "validation"))]
+    let QueryAttribute{ attr, value } = QueryAttribute::from(pk11_qattr);
     attr.assign(value, mapping)
 }

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -115,6 +115,7 @@ fn spec_examples_all_parse() {
 
 /// Attributes whose values are text may not contain spaces.
 #[test]
+#[cfg(feature = "validation")]
 fn text_values_with_empty_spaces_are_not_valid() {
     let pk11_uri = "pkcs11:token=contains empty spaces";
     parse(pk11_uri).expect_err("empty space(s) in value should not be valid");
@@ -164,6 +165,7 @@ fn text_values_with_empty_spaces_are_not_valid() {
 
 /// Attributes whose values are text may not contain the '#' char.
 #[test]
+#[cfg(feature = "validation")]
 fn text_values_with_hash_char_are_not_valid() {
     let pk11_uri = "pkcs11:token=contains#";
     parse(pk11_uri).expect_err("'#' in value should not be valid");
@@ -213,6 +215,7 @@ fn text_values_with_hash_char_are_not_valid() {
 
 /// Path attributes whose value is text may not contain the '/' char.
 #[test]
+#[cfg(feature = "validation")]
 fn path_text_values_with_backslash_not_valid() {
     let pk11_uri = "pkcs11:token=foo/bar";
     parse(pk11_uri).expect_err("'/' in value should not be valid");
@@ -251,6 +254,7 @@ fn path_text_values_with_backslash_not_valid() {
 /// Attempting to use a standard query component attribute name
 /// in the PKCS#11 URI path is not valid.
 #[test]
+#[cfg(feature = "validation")]
 fn query_component_naming_collision_are_not_valid() {
     let pk11_uri = "pkcs11:pin-value=foo";
     parse(pk11_uri).expect_err("query component naming collision should not be valid");
@@ -268,6 +272,7 @@ fn query_component_naming_collision_are_not_valid() {
 /// Attempting to use a standard path component attribute name
 /// in the PKCS#11 URI query is not valid.
 #[test]
+#[cfg(feature = "validation")]
 fn path_component_naming_collision_are_not_valid() {
     let pk11_uri = "pkcs11:?token=foo";
     parse(pk11_uri).expect_err("path component naming collision should not be valid");
@@ -335,6 +340,7 @@ fn type_has_finite_values() {
 
 /// The `pk11-lib-ver` needs to be `1*DIGIT [ "." 1*DIGIT ]`
 #[test]
+#[cfg(feature = "validation")]
 fn library_version_is_major_dot_minor() {
     let pk11_uri = "pkcs11:library-version=1";
     let mapping = parse(pk11_uri).expect("mapping should be valid");
@@ -362,6 +368,7 @@ fn library_version_is_major_dot_minor() {
 
 /// The `pk11-slot-id` needs to be `1*DIGIT`
 #[test]
+#[cfg(feature = "validation")]
 fn slot_id_needs_to_be_numeric() {
     let pk11_uri = "pkcs11:slot-id=1";
     let mapping = parse(pk11_uri).expect("mapping should be valid");
@@ -380,6 +387,7 @@ fn slot_id_needs_to_be_numeric() {
 
 /// No exceptions to no duplicate path attribute names
 #[test]
+#[cfg(feature = "validation")]
 fn duplicate_path_attributes_are_not_valid() {
     let pk11_uri = "pkcs11:token=foo;token=bar";
     parse(pk11_uri).expect_err("duplicate token attribute names should not be valid");
@@ -430,6 +438,7 @@ fn duplicate_path_attributes_are_not_valid() {
 /// Standard query attribute names may not appear more than
 /// once in a PKCS#11 query.
 #[test]
+#[cfg(feature = "validation")]
 fn duplicate_standard_query_attributes_are_not_allowed() {
     let pk11_uri = "pkcs11:?pin-source=foo&pin-source=bar";
     parse(pk11_uri).expect_err("duplicate pin-source attribute names should be not valid");


### PR DESCRIPTION
Adds capability to remove validation and warnings functionality.  The intent here is why require runtime validation if a user is confident their input(s) will _always_ be valid?  The default feature set is to still do the validation and debug warnings.